### PR TITLE
feat: display fancy tables for ls and ps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tabled",
  "tempfile",
  "tokio",
  "tower",
@@ -237,6 +238,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "byteorder"
@@ -1070,6 +1077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1170,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1559,6 +1599,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1569,6 +1633,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1792,6 +1865,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,6 @@ tower = "0.4"
 atty = "0.2"
 base64 = "0.21"
 once_cell = "1.19"
+tabled = "0.20"
 
 [dev-dependencies]

--- a/tests/container_test.rs
+++ b/tests/container_test.rs
@@ -10,6 +10,9 @@ mod settings;
 #[path = "../src/language.rs"]
 mod language;
 
+#[path = "../src/state.rs"]
+mod state;
+
 #[path = "../src/container/mod.rs"]
 mod container;
 
@@ -229,8 +232,8 @@ async fn create_container_masks_only_existing_env_files() {
         false,
         false,
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     env::set_var("PATH", original_path);
 
@@ -265,7 +268,11 @@ async fn create_container_isolates_node_modules_and_copies_from_host() {
     let project_dir = tmp.path().join("proj-node");
     fs::create_dir(&project_dir).expect("create project dir");
     // Minimal Node project
-    fs::write(project_dir.join("package.json"), "{\n  \"name\": \"test\"\n}\n").unwrap();
+    fs::write(
+        project_dir.join("package.json"),
+        "{\n  \"name\": \"test\"\n}\n",
+    )
+    .unwrap();
     // Create a host node_modules with a file to verify copy
     let nm_dir = project_dir.join("node_modules");
     fs::create_dir_all(nm_dir.join(".keep")).unwrap();
@@ -319,15 +326,14 @@ esac
     let run_args = fs::read_to_string(&run_log).unwrap();
     let node_modules_path = project_dir.join("node_modules");
     // Ensure the node_modules anonymous volume is present in run args
-    assert!(run_args.contains(&format!(" {} ", node_modules_path.display()))
-        || run_args.ends_with(&format!(" {}", node_modules_path.display()))
-        || run_args.starts_with(&format!("{} ", node_modules_path.display())));
+    assert!(
+        run_args.contains(&format!(" {} ", node_modules_path.display()))
+            || run_args.ends_with(&format!(" {}", node_modules_path.display()))
+            || run_args.starts_with(&format!("{} ", node_modules_path.display()))
+    );
 
     // Ensure docker cp was invoked to copy node_modules
     let cp_args = fs::read_to_string(&cp_log).unwrap();
-    let expected_dest = format!(
-        "test-node:{}",
-        project_dir.join("node_modules").display()
-    );
+    let expected_dest = format!("test-node:{}", project_dir.join("node_modules").display());
     assert!(cp_args.contains(&expected_dest));
 }

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -10,6 +10,9 @@ mod settings;
 #[path = "../src/language.rs"]
 mod language;
 
+#[path = "../src/state.rs"]
+mod state;
+
 #[path = "../src/container/mod.rs"]
 mod container;
 

--- a/tests/runtime_test.rs
+++ b/tests/runtime_test.rs
@@ -10,6 +10,9 @@ mod language;
 #[path = "../src/settings.rs"]
 mod settings;
 
+#[path = "../src/state.rs"]
+mod state;
+
 #[path = "../src/container/mod.rs"]
 mod container;
 
@@ -17,22 +20,14 @@ use std::path::Path;
 
 #[test]
 fn build_command_includes_continue() {
-    let cmd = container::build_agent_command(
-        Path::new("/project"),
-        &cli::Agent::Claude,
-        true,
-        None,
-    );
+    let cmd =
+        container::build_agent_command(Path::new("/project"), &cli::Agent::Claude, true, None);
     assert!(cmd.contains("claude --continue"));
 }
 
 #[test]
 fn build_command_without_continue() {
-    let cmd = container::build_agent_command(
-        Path::new("/project"),
-        &cli::Agent::Claude,
-        false,
-        None,
-    );
+    let cmd =
+        container::build_agent_command(Path::new("/project"), &cli::Agent::Claude, false, None);
     assert!(!cmd.contains("--continue"));
 }


### PR DESCRIPTION
## Summary
- render ls/ps output as rounded tables using the `tabled` crate
- add `tabled` dependency and adjust tests to compile with new modules

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test` *(fails: serves_frontend_container_route, serves_frontend_index)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fde1a064832f99d9c3c396be0fed